### PR TITLE
feat: configuration profiles (`--profile`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "arraybuffer-to-buffer": "^0.0.7",
     "chalk": "^5.0.1",
     "commander": "^9.3.0",
+    "common-tags": "^1.8.2",
     "esm": "https://github.com/jsg2021/esm/releases/download/v3.x.x-pr883/esm-3.x.x-pr883.tgz",
     "form-data": "^4.0.0",
     "gitignore-to-glob": "^0.3.0",
@@ -41,11 +42,14 @@
     "p-map": "^5.5.0",
     "prettier": "^2.7.1",
     "prettify": "^0.1.7",
+    "reflect-metadata": "^0.1.13",
     "truffle-dev-server": "github:trufflehq/truffle-dev-server",
+    "tsyringe": "^4.7.0",
     "undici": "^5.8.0",
     "watch-glob": "^0.1.3"
   },
   "devDependencies": {
+    "@types/common-tags": "^1",
     "@types/lodash": "^4.14.182",
     "@types/node": "^18.6.2",
     "@typescript-eslint/eslint-plugin": "^5.31.0",

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -8,7 +8,9 @@ export default async function auth ({ secretKey }: { secretKey: string }) {
   const configFilename = getConfigFilename()
   fs.mkdirSync(path.dirname(configFilename), { recursive: true })
   fs.writeFileSync(configFilename, JSON.stringify({
-    apiUrl: 'https://mycelium.staging.bio/graphql', // FIXME
-    secretKey
+    default: {
+      apiUrl: 'https://mycelium.staging.bio/graphql', // FIXME
+      secretKey
+    }
   }))
 }

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -1,0 +1,56 @@
+import { request } from '../util/request.js'
+import { getGlobalConfig, kProfile } from '../util/config.js'
+import { stripIndents } from 'common-tags'
+import chalk from 'chalk'
+import { container } from 'tsyringe'
+
+export default async function whoami () {
+  const profile = container.resolve<string>(kProfile)
+  const globalConfig = getGlobalConfig(profile)
+
+  const res = await request({
+    shouldUseGlobal: true,
+    query: `
+    query APIKeyWhoami($secretKey: String!) {
+      apiKey(secretKey: $secretKey) {
+        id
+        orgId
+        type
+        key
+        source {
+          id
+          slug
+          name
+          __typename
+        }
+        __typename
+      }
+    }
+  `,
+    variables: { secretKey: globalConfig.secretKey }
+  })
+
+  const data = res.data.apiKey as {
+    id: string;
+    orgId: string;
+    type: string;
+    key: string;
+    source: {
+      id: string;
+      slug: string;
+      name: string;
+      __typename: string;
+    };
+    __typename: string;
+  }
+
+  const type = data.type === 'secret' ? chalk.red('secret') : chalk.green('publishable')
+
+  console.log(stripIndents`
+    Your API key for ${chalk.cyan(globalConfig.apiUrl)} (${chalk.gray(globalConfig.secretKey.slice(0, 8))}) is:
+    - configured under profile ${chalk.bold(profile)}
+    - a ${type} key
+    - belonging to ${data.source.__typename.toLocaleLowerCase()}:${data.source.name} (${data.source.slug})
+    - with a uuid of ${chalk.gray(data.id)}
+  `)
+}

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -58,8 +58,9 @@ export function getConfigFilename () {
   return path.resolve(os.homedir(), path.normalize('.truffle/config.json'))
 }
 
-const warning = `[config] DepricationWarning: Housing one truffle-cli config in ~/.truffle/config.json has been deprecated.
+const warning = `[config] DeprecationWarning: Housing one truffle-cli config in ~/.truffle/config.json has been deprecated.
 Scope your profiles in an object: "{ "default": { "apiURL": "...", "secretKey": "..." } }".
+See: https://github.com/trufflehq/truffle-cli/pull/10
 `
 
 function configIsOldFormat (config: GlobalConfig): config is GlobalConfigData {

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -2,6 +2,8 @@ import fs from 'fs'
 import path from 'path'
 import os from 'os'
 
+export const kProfile = Symbol.for('profile')
+
 export interface PrivateConfig {
   secretKey: string;
   secrets: Record<string, Record<string, string>>;
@@ -45,12 +47,39 @@ export interface PublicConfig {
   }[]
 }
 
+interface GlobalConfigData {
+  apiUrl: string
+  secretKey: string
+}
+
+type GlobalConfig = Record<string, GlobalConfigData> | GlobalConfigData // compat
+
 export function getConfigFilename () {
   return path.resolve(os.homedir(), path.normalize('.truffle/config.json'))
 }
 
-export function getGlobalConfig () {
-  return JSON.parse(fs.readFileSync(getConfigFilename()).toString('utf-8'))
+const warning = `[config] DepricationWarning: Housing one truffle-cli config in ~/.truffle/config.json has been deprecated.
+Scope your profiles in an object: "{ "default": { "apiURL": "...", "secretKey": "..." } }".
+`
+
+function configIsOldFormat (config: GlobalConfig): config is GlobalConfigData {
+  return 'apiUrl' in config
+}
+let warned = false
+
+export function getGlobalConfig (profile = 'default'): GlobalConfigData {
+  const parsed: GlobalConfig = JSON.parse(fs.readFileSync(getConfigFilename(), { encoding: 'utf-8' }))
+
+  // throw a deprecation warning if the config is in the old format
+  if (configIsOldFormat(parsed)) {
+    if (!warned) {
+      warned = true
+      console.warn(warning)
+    }
+    return parsed as GlobalConfigData
+  }
+
+  return parsed[profile!]
 }
 
 export async function getPublicPackageConfig () {

--- a/src/util/request.ts
+++ b/src/util/request.ts
@@ -2,7 +2,6 @@ import { getPackageConfig, getGlobalConfig, kProfile } from './config.js'
 import FormData from 'form-data'
 import fetch from 'node-fetch'
 import { container } from 'tsyringe'
-import chalk from 'chalk'
 
 export interface RequestOptions {
   query: string;

--- a/src/util/request.ts
+++ b/src/util/request.ts
@@ -18,7 +18,6 @@ interface BaseGraphQLResponse {
 
 export async function request ({ query, variables, shouldUseGlobal = false, maxAttempts = 1 }: RequestOptions): Promise<any> {
   const profile = container.resolve<string>(kProfile)
-  console.log(chalk.gray(`[debug]: loaded profile ${profile}`))
 
   const { apiUrl, secretKey } = shouldUseGlobal ? getGlobalConfig(profile) : await getPackageConfig() || getGlobalConfig(profile)
   let response
@@ -59,7 +58,6 @@ export interface UploadOptions {
 
 export async function upload ({ query, variables, bundle, shouldUseGlobal = false }: UploadOptions): Promise<any> {
   const profile = container.resolve<string>(kProfile)
-  console.log(chalk.gray(`[debug]: loaded profile ${profile}`))
 
   const { apiUrl, secretKey } = shouldUseGlobal ? getGlobalConfig(profile) : await getPackageConfig() || getGlobalConfig(profile)
   const url = new URL(apiUrl)

--- a/src/util/request.ts
+++ b/src/util/request.ts
@@ -1,6 +1,8 @@
-import { getPackageConfig, getGlobalConfig } from './config.js'
+import { getPackageConfig, getGlobalConfig, kProfile } from './config.js'
 import FormData from 'form-data'
 import fetch from 'node-fetch'
+import { container } from 'tsyringe'
+import chalk from 'chalk'
 
 export interface RequestOptions {
   query: string;
@@ -15,7 +17,10 @@ interface BaseGraphQLResponse {
 }
 
 export async function request ({ query, variables, shouldUseGlobal = false, maxAttempts = 1 }: RequestOptions): Promise<any> {
-  const { apiUrl, secretKey } = shouldUseGlobal ? getGlobalConfig() : await getPackageConfig() || getGlobalConfig()
+  const profile = container.resolve<string>(kProfile)
+  console.log(chalk.gray(`[debug]: loaded profile ${profile}`))
+
+  const { apiUrl, secretKey } = shouldUseGlobal ? getGlobalConfig(profile) : await getPackageConfig() || getGlobalConfig(profile)
   let response
   let attemptsLeft = maxAttempts
   while ((!response || response.status !== 200) && attemptsLeft > 0) {
@@ -53,7 +58,10 @@ export interface UploadOptions {
 }
 
 export async function upload ({ query, variables, bundle, shouldUseGlobal = false }: UploadOptions): Promise<any> {
-  const { apiUrl, secretKey } = shouldUseGlobal ? getGlobalConfig() : await getPackageConfig() || getGlobalConfig()
+  const profile = container.resolve<string>(kProfile)
+  console.log(chalk.gray(`[debug]: loaded profile ${profile}`))
+
+  const { apiUrl, secretKey } = shouldUseGlobal ? getGlobalConfig(profile) : await getPackageConfig() || getGlobalConfig(profile)
   const url = new URL(apiUrl)
   url.pathname = '/upload'
   url.searchParams.set('graphqlQuery', query)

--- a/yarn.lock
+++ b/yarn.lock
@@ -700,6 +700,7 @@ __metadata:
   resolution: "@trufflehq/cli@workspace:."
   dependencies:
     "@deno/eszip": ^0.22.0
+    "@types/common-tags": ^1
     "@types/lodash": ^4.14.182
     "@types/node": ^18.6.2
     "@typescript-eslint/eslint-plugin": ^5.31.0
@@ -707,6 +708,7 @@ __metadata:
     arraybuffer-to-buffer: ^0.0.7
     chalk: ^5.0.1
     commander: ^9.3.0
+    common-tags: ^1.8.2
     eslint: ^7.32.0
     eslint-config-standard: ^16.0.3
     eslint-plugin-import: ^2.25.3
@@ -722,7 +724,9 @@ __metadata:
     pkg: ^5.8.0
     prettier: ^2.7.1
     prettify: ^0.1.7
+    reflect-metadata: ^0.1.13
     truffle-dev-server: "github:trufflehq/truffle-dev-server"
+    tsyringe: ^4.7.0
     typescript: ^4.7.4
     undici: ^5.8.0
     watch-glob: ^0.1.3
@@ -730,6 +734,13 @@ __metadata:
     truffle-cli: ./dist/src/cli.js
   languageName: unknown
   linkType: soft
+
+"@types/common-tags@npm:^1":
+  version: 1.8.1
+  resolution: "@types/common-tags@npm:1.8.1"
+  checksum: bec6f68c8c434834380abd1dc057aa6ba26661bb0c65c700b65049e9b104d7be96a987d93dbe8726be68554a23a52514a6967d8903fdb51fb8c78cf909d1e4c1
+  languageName: node
+  linkType: hard
 
 "@types/json-schema@npm:^7.0.9":
   version: 7.0.11
@@ -1728,6 +1739,13 @@ __metadata:
   version: 9.4.0
   resolution: "commander@npm:9.4.0"
   checksum: a322de584a6ccd1ea83c24f6a660e52d16ffbe2613fcfbb8d2cc68bc9dec637492456d754fe8bb5b039ad843ed8e04fb0b107e581a75f62cde9e1a0ab1546e09
+  languageName: node
+  linkType: hard
+
+"common-tags@npm:^1.8.2":
+  version: 1.8.2
+  resolution: "common-tags@npm:1.8.2"
+  checksum: 767a6255a84bbc47df49a60ab583053bb29a7d9687066a18500a516188a062c4e4cd52de341f22de0b07062e699b1b8fe3cfa1cb55b241cb9301aeb4f45b4dff
   languageName: node
   linkType: hard
 
@@ -5114,6 +5132,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"reflect-metadata@npm:^0.1.13":
+  version: 0.1.13
+  resolution: "reflect-metadata@npm:0.1.13"
+  checksum: 798d379a7b6f6455501145419505c97dd11cbc23857a386add2b9ef15963ccf15a48d9d15507afe01d4cd74116df8a213247200bac00320bd7c11ddeaa5e8fb4
+  languageName: node
+  linkType: hard
+
 "regex-not@npm:^1.0.0, regex-not@npm:^1.0.2":
   version: 1.0.2
   resolution: "regex-not@npm:1.0.2"
@@ -5949,7 +5974,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.8.1":
+"tslib@npm:^1.8.1, tslib@npm:^1.9.3":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
@@ -5971,6 +5996,15 @@ __metadata:
   peerDependencies:
     typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
   checksum: 1843f4c1b2e0f975e08c4c21caa4af4f7f65a12ac1b81b3b8489366826259323feb3fc7a243123453d2d1a02314205a7634e048d4a8009921da19f99755cdc48
+  languageName: node
+  linkType: hard
+
+"tsyringe@npm:^4.7.0":
+  version: 4.7.0
+  resolution: "tsyringe@npm:4.7.0"
+  dependencies:
+    tslib: ^1.9.3
+  checksum: 6d84e0767538fabf60eafb926bd285d08d25847875b635f8a3ab8b3093c8814aca4f47072fbb51837bd431259dc2464572e5c28a838b833c9ef097d5b1a895b3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR introduces configuration profiles -- similar to that of [`.aws/config`](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-settings:~:text=~/.aws/credentials,output%3Djson) or [`.ssh/config`](https://man7.org/linux/man-pages/man5/ssh_config.5.html), however in JSON form!  
**The default configuration should be scoped under `default`**.  

Additionally, this PR creates the `whoami` command, which provides some metadata on the profile being used.

#### `~/.truffle/config.json` changes
**Before**
```json
{
	"secretKey": "sk_****",
	"apiUrl": "https://"
}
```  
**After**
```json
{
	"default": {
		"secretKey": "sk_****",
		"apiUrl": "https://"
	}
}
```

#### `truffle-cli` changes
**Before**
```sh
# this assumes you use symlinks to manage multiple config files
$ rm ~/.truffle/config.json
$ ln -s ~/.truffle/staging.json ~/.truffle/config.json
$ truffle-cli whoami
```
**After**
```sh
$ truffle-cli --profile=staging whoami
```

### Recipes
**Adding a new config**
```diff
{
	"default": {
		"secretKey": "sk_****",
		"apiUrl": "https://"
-	}
+ 	},
+ 	"staging": {
+ 		"secretKey": "sk_***",
+		"apiUrl": "https://"
+	}
}
```