### PR TITLE
feat: get-package-token command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trufflehq/cli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "The Truffle Developer Platform CLI",
   "main": "dist/cli.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trufflehq/cli",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "The Truffle Developer Platform CLI",
   "main": "dist/cli.js",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -170,8 +170,9 @@ program.addCommand(
 )
 
 program.addCommand(
-  new Command('get-package-token')
+  new Command('get-package-user-access-token')
     .description('Get a package-install scoped user access token for testing.')
+    .alias('pt')
     .action(actionLoader('commands/package-token.js'))
 )
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -170,6 +170,12 @@ program.addCommand(
 )
 
 program.addCommand(
+  new Command('get-package-token')
+    .description('Get a package-install scoped user access token for testing.')
+    .action(actionLoader('commands/package-token.js'))
+)
+
+program.addCommand(
   new Command('regenerate-api-key')
     .description('Request a new API Key.')
     .action(actionLoader('commands/regenerate.js'))

--- a/src/commands/package-token.ts
+++ b/src/commands/package-token.ts
@@ -1,0 +1,15 @@
+import { packageInstallGet, packageInstallTokenGet } from "../util/package-install.js";
+
+export default async function () {
+  const packageInstall = await packageInstallGet();
+
+  if (!packageInstall) {
+    console.error("No package install found. You might have to deploy it first.");
+    return;
+  }
+
+  console.log(`Retrieving auth token for package install ${packageInstall.id}\n`);
+
+  const token = await packageInstallTokenGet(packageInstall.id);
+  console.log(token);
+}

--- a/src/util/org.ts
+++ b/src/util/org.ts
@@ -43,7 +43,8 @@ export async function getOrg(input: OrgInput) {
 export async function createOrg ({ name }: { name: string }) {
   const response = await request({
     query: ORG_CREATE_MUTATION,
-    variables: { name }
+    variables: { name },
+    isOrgRequired: false,
   })
   return response.data.orgCreate.org as Org
 }

--- a/src/util/package-install.ts
+++ b/src/util/package-install.ts
@@ -86,5 +86,5 @@ export async function packageInstallTokenGet(packageInstallId: string) {
     isOrgRequired: false,
     shouldUseGlobal: true
   });
-  return res.data?.packageInstallToken as string;
+  return res.data?.packageInstallUserAccessToken as string;
 }

--- a/src/util/package-install.ts
+++ b/src/util/package-install.ts
@@ -76,7 +76,7 @@ export async function packageInstallGet (options?: { packagePath: string }) {
 export async function packageInstallTokenGet(packageInstallId: string) {
   const query = `
     query PackageInstallTokenGet($packageInstallId: ID!) {
-      packageInstallToken(input: { packageInstallId: $packageInstallId })
+      packageInstallUserAccessToken(input: { packageInstallId: $packageInstallId })
     }
   `;
 

--- a/src/util/package-install.ts
+++ b/src/util/package-install.ts
@@ -1,5 +1,6 @@
 import { request } from './request.js'
 import { packageVersionGet } from './package-version.js'
+import { getPackageConfig } from './config.js';
 
 interface PackageInstallCreateOptions {
   installedPackageVersionPath: string
@@ -35,4 +36,55 @@ export async function packageInstallCreate ({ installedPackageVersionPath, isFor
   } catch (err) {
     return err.message
   }
+}
+
+interface PackageInstall {
+  id: string;
+  installStatus: string;
+}
+
+export async function packageInstallGet (options?: { packagePath: string }) {
+  let { packagePath } = options || {}
+
+  if (!packagePath) {
+    packagePath = (await getPackageConfig())?.name ?? '';
+
+    if (!packagePath) {
+      console.log("Package path not specified in config.")
+      return
+    }
+  }
+
+  const query = `
+    query PackageInstallGet($packagePath: String!) {
+      packageInstall(input: { packagePath: $packagePath }) {
+        id
+        installStatus
+      }
+    }
+  `;
+
+  const res = await request({
+    query,
+    variables: { packagePath },
+    isOrgRequired: false,
+    shouldUseGlobal: true
+  });
+  return res.data?.packageInstall as PackageInstall;  
+}
+
+export async function packageInstallTokenGet(packageInstallId: string) {
+  const query = `
+    query PackageInstallTokenGet($packageInstallId: ID!) {
+      packageInstallToken(input: { packageInstallId: $packageInstallId })
+    }
+  `;
+
+  const res = await request({
+    query,
+    variables: { packageInstallId },
+    isOrgRequired: false,
+    shouldUseGlobal: true
+  });
+  return res.data?.packageInstallToken as string;
 }


### PR DESCRIPTION
Adds the `truffle-cli get-package-user-access-token` command. When executed inside of a package directory (with truffle.config.mjs), the cli will retrieve a package-scoped user access token that devs can use for testing.